### PR TITLE
Fix date deletion

### DIFF
--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -31,10 +31,10 @@ def record_animations(config, controller_path, opponent_controller_path=None):
     # Create temporary directory
     subprocess.check_output(['mkdir', '-p', TMP_ANIMATION_DIRECTORY])
 
-    # Temporary file changes*:
+    # Temporary world file changes
     with open(world_config['file'], 'r') as f:
-        world_content = f.read()
-    world_content = world_content.replace(f'controller "{default_controller_name}"', 'controller "<extern>"')
+        original_world_content = f.read()
+    world_content = original_world_content.replace(f'controller "{default_controller_name}"', 'controller "<extern>"')
     if opponent_controller_path:
         world_content = world_content.replace(f'controller "opponent"', 'controller "<extern>"')
     world_content += f'''
@@ -196,7 +196,7 @@ def record_animations(config, controller_path, opponent_controller_path=None):
 
     # restore temporary file changes
     with open(world_config['file'], 'w') as f:
-        f.write(world_content)
+        f.write(original_world_content)
 
     # compute performance line
     metric = world_config['metric']

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -133,6 +133,8 @@ def _update_participant(p, participant, performance=None, date=True):
         p['performance'] = performance
     if date:
         p['date'] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        p['date'] = participant.data['date'] # keep the original date
 
 
 def _update_performance(performance, participant, higher_is_better):
@@ -181,7 +183,7 @@ def _update_ranking(performance, participant, opponent):
             _update_participant(found_participant, participant)
             _save_participants(participants)
             return
-        # we need to add the partipant at the bottom of the list
+        # we need to add the participant at the bottom of the list
         p = {}
         _update_participant(p, participant, count)
         participants['participants'].append(p)


### PR DESCRIPTION
This PR fixes a problem where the last participant in the ranking would lose its date if it was beaten by a newcomer.

There is also another fix that correct a bug where the animator controller would not be removed from the world file between evaluations so a new animator would be added at each new duel.