### PR TITLE
IPC communication between dockers

### DIFF
--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -128,7 +128,7 @@ def record_animations(gpu, config, participant_controller_path, participant_name
     command_line = ['docker', 'run', '--tty', '--rm']
     if gpu:
         command_line += ['--gpus=all', '--env', 'DISPLAY',
-                         '--volume', '/tmp/.X11-unix:/tmp/.X11-unix:rw']
+                         '--volume', '/tmp/.X11-unix:/tmp/.X11-unix:ro']
     else:
         command_line += ['--init']
 

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -187,15 +187,19 @@ def record_animations(gpu, config, participant_controller_path, participant_name
             continue
         print(f'\033[32m{webots_line}\033[0m')
         if "' extern controller: waiting for connection on ipc://" in webots_line:
+            command_line = ['docker', 'run', '--rm']
+            if gpu:
+                command_line += ['--gpus', 'all']
+            command_line += ['--network', 'none', '--volume']
             if participant_docker is None and "INFO: 'participant' " in webots_line:
-                participant_docker = subprocess.Popen(['docker', 'run', '--rm', '--network', 'none', '--volume',
-                                                       '/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant',
-                                                       'participant-controller'],
+                command_line += ['/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant',
+                                 'participant-controller']
+                participant_docker = subprocess.Popen(command_line,
                                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
             elif opponent_docker is None and "INFO: 'opponent' " in webots_line:
-                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', '--network', 'none', '--volume',
-                                                    '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent',
-                                                    'opponent-controller'],
+                command_line += ['/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent',
+                                 'opponent-controller']
+                opponent_docker = subprocess.Popen(command_line,
                                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
         elif "' extern controller: connected" in webots_line:
             if "INFO: 'participant' " in webots_line:

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -188,12 +188,14 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'\033[32m{webots_line}\033[0m')
         if "' extern controller: waiting for connection on ipc://" in webots_line:
             if participant_docker is None and "INFO: 'participant' " in webots_line:
-                participant_docker = subprocess.Popen(['docker', 'run', '--rm', 'participant-controller', '--volume',
-                                                       '/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant'],
+                participant_docker = subprocess.Popen(['docker', 'run', '--rm', '--network', 'none', '--volume',
+                                                       '/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant',
+                                                       'participant-controller'],
                                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
             elif opponent_docker is None and "INFO: 'opponent' " in webots_line:
-                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', 'opponent-controller', '--volume',
-                                                    '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent'],
+                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', '--network', 'none', '--volume',
+                                                    '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent',
+                                                    'opponent-controller'],
                                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
         elif "' extern controller: connected" in webots_line:
             if "INFO: 'participant' " in webots_line:

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -132,7 +132,7 @@ def record_animations(gpu, config, participant_controller_path, participant_name
     else:
         command_line += ['--init']
 
-    if opponent_controlller_path:
+    if opponent_controller_path:
         command_line += ['--volume', '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent']
 
     command_line += [

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -81,7 +81,7 @@ def record_animations(gpu, config, participant_controller_path, participant_name
                 'docker', 'build',
                 '--tag', 'participant-controller',
                 '--file', f'{participant_controller_path}/controllers/Dockerfile',
-                '--build-arg', 'WEBOTS_CONTROLLER_URL=tcp://172.17.0.1:3005/participant',
+                '--build-arg', 'WEBOTS_CONTROLLER_URL=participant',
                 f'{participant_controller_path}/controllers'
             ],
             stdout=subprocess.PIPE,
@@ -101,7 +101,7 @@ def record_animations(gpu, config, participant_controller_path, participant_name
                 'docker', 'build',
                 '--tag', 'opponent-controller',
                 '--file', f'{opponent_controller_path}/controllers/Dockerfile',
-                '--build-arg', 'WEBOTS_CONTROLLER_URL=tcp://172.17.0.1:3005/opponent',
+                '--build-arg', 'WEBOTS_CONTROLLER_URL=opponent',
                 f'{opponent_controller_path}/controllers'
             ],
             stdout=subprocess.PIPE,
@@ -132,11 +132,14 @@ def record_animations(gpu, config, participant_controller_path, participant_name
     else:
         command_line += ['--init']
 
+    if opponent_controlller_path:
+        command_line += ['--volume', '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent']
+
     command_line += [
+        '--volume', '/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant',
         '--mount', 'type=bind,' +
                    f'source={os.getcwd()}/{TMP_ANIMATION_DIRECTORY},' +
                    f'target=/usr/local/webots-project/{TMP_ANIMATION_DIRECTORY}',
-        '--publish', '3005:1234',
         '--env', 'CI=true',
         '--env', f'PARTICIPANT_NAME={participant_name}',
         '--env', f'OPPONENT_NAME={opponent_name}',
@@ -185,10 +188,12 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'\033[32m{webots_line}\033[0m')
         if "' extern controller: waiting for connection on ipc://" in webots_line:
             if participant_docker is None and "INFO: 'participant' " in webots_line:
-                participant_docker = subprocess.Popen(['docker', 'run', '--rm', 'participant-controller'],
+                participant_docker = subprocess.Popen(['docker', 'run', '--rm', 'participant-controller', '--volume',
+                                                       '/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant'],
                                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
             elif opponent_docker is None and "INFO: 'opponent' " in webots_line:
-                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', 'opponent-controller'],
+                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', 'opponent-controller', '--volume',
+                                                    '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent'],
                                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
         elif "' extern controller: connected" in webots_line:
             if "INFO: 'participant' " in webots_line:

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -188,12 +188,12 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'\033[32m{webots_line}\033[0m')
         if "' extern controller: waiting for connection on ipc://" in webots_line:
             if participant_docker is None and "INFO: 'participant' " in webots_line:
-                participant_docker = subprocess.Popen(['docker', 'run', '--rm', '--gpus', 'all', '--network', 'none', '--volume',
+                participant_docker = subprocess.Popen(['docker', 'run', '--rm', '--network', 'none', '--volume',
                                                        '/tmp/webots-1234/ipc/participant:/tmp/webots-1234/ipc/participant',
                                                        'participant-controller'],
                                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
             elif opponent_docker is None and "INFO: 'opponent' " in webots_line:
-                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', '--gpus', 'all', '--network', 'none', '--volume',
+                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', '--network', 'none', '--volume',
                                                     '/tmp/webots-1234/ipc/opponent:/tmp/webots-1234/ipc/opponent',
                                                     'opponent-controller'],
                                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')


### PR DESCRIPTION
Fixes #17.

In addition to fixing #17 and provide a better performance, this PR:

- [x] disables networking inside the controller docker containers. This prevents participants to cheat by remote controlling their robot.
- [x] change the X11 volume right to "ro" instead of "rw".
- [x] fixes controller execution on non-GPU host.