### PR TITLE
Using GitHub's inputs instead of environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-py_local_test.sh
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Competition Record Action
 
-This composite action is to be used with Webots competitions.
-It records an animation and the performance of a participant in a competition. An optional setting can be set to push the changes to GitHub at the end of the evaluation.
+This is a composite action designed to be used with Webots competitions. It records a participant's performance in a competition, as well as an animation of the participant's robot in action. This action is able to detect whether the GitHub runner being used is capable of GPU acceleration (e.g. if using a self-hosted runner). Additionally, there is an optional setting that allows for the changes to be pushed to webots.cloud at the end of the evaluation.
+
 For more information on Webots competitions please refer to the competition template [here](https://github.com/cyberbotics/competition-template/blob/main/README.md).
 
-## Input
+## Inputs
 
-This composite action works with environment variables as input, two mandatory and one optional:
-
-### Mandatory Input
+### Mandatory
 
 | Name | Description |
 | --- | --- |
@@ -18,9 +16,9 @@ This composite action works with environment variables as input, two mandatory a
 | `log_url` | The URL of GitHub action logs |
 | `repo_token` | Token used to fetch the participant repository, typically REPO_TOKEN |
 
-A more privileged token than GITHUB_TOKEN is needed to fetch controllers from private repositories.
+Note that a more privileged token than `GITHUB_TOKEN` is required to fetch controllers from private repositories.
 
-### Optional Input
+### Optional
 
 | Name | Description | Default |
 | --- | --- | --- |
@@ -28,38 +26,29 @@ A more privileged token than GITHUB_TOKEN is needed to fetch controllers from pr
 
 ## Python Code Pipeline
 
-First, the `webots.yml` file is parsed to get several competition parameters. Then the script performs the following steps:
+First, the competition's `webots.yml` file is parsed to get several competition parameters. It then detects if the GitHub runner has GPU capabilities. Finally the script performs the following steps:
 
-### 1. Get the Participants
+### 1. Fetch the participant's controller
 
-We parse the `INPUT_INDIVIDUAL_EVALUATION` environment variable to get the **id**, the **controller repository** and the **private** status needed in the rest of the code.
+A `Participant` class is defined to store all the information about a participant and to download its controller files.
+The controller to be tested is initialized using the `participant_repo_id`, `participant_repo_name` and `participant_repo_private` inputs.
 
-### 2. Clone the Participant Repositories
-
-We clone the participant **repository** into the competition `controllers/` directory and rename it using the GitHub repository: `{id}`.
-
-### 3. Run Webots and Record Animations
+### 2. Run Webots and Record Animations
 
 We create a temporary storage directory `/tmp` and modify the world file to add a `Supervisor` running the `animator.py` controller and we set the robot's controller to \<extern\>.
 
-We then run Webots and the controller of the participant inside Docker containers. We first launch Webots and when it is waiting for a connection of an external controller, we launch the controller container.
+We then run Webots and the participant's controller inside Docker containers. We first launch Webots and when it is waiting for a connection of an external controller, we launch the controller container.
 
 The animator records and saves the animation files and the competition performance in the temporary storage.
 
-The animation files are renamed as `animation.json` and `scene.x3d` files and are moved to their own directory `storage/wb_animation_{id}`. If there is an old animation, it gets overwritten.
+If the competition is in a tournament format, the controller keeps on duelling the controller above it in the ranking until it loses in a bubble-sort logic.
+
+The JSON animation file is renamed as `animation.json` and is moved to a directory `storage/{id}`.
 The `participants.json` file is also updated with the new recorded performance.
 
-### 4. Remove temporary files
+### 3. Upload performances to webots.cloud (if UPLOAD_PERFORMANCES is set)
 
-We remove the various temporary files so that only the updated files of interest are left.
-
-### 5. Commit and push updates (if INPUT_ALLOW_PUSH is set)
-
-All of the updates are committed and pushed to the repository of the competition organizer.
-The modified directories and files are therefore:
-
-- `participants.json`
-- `storage/wb_animation_{id}`
+If `UPLOAD_PERFORMANCES` is set, `animation.json` and the updated `participants.json` are uploaded to webots.cloud.
 
 ## Workflow
 
@@ -68,8 +57,11 @@ Here is a GitHub workflow snippet which uses the composite action:
 ```yaml
 - name: Record and update animations
   uses: cyberbotics/competition-record-action@main
-  env:
-    INPUT_INDIVIDUAL_EVALUATION: "1876568742:username/repository_name:true"
-    INPUT_REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
-    INPUT_ALLOW_PUSH: True
+  with:
+    participant_repo_id: ${{ env.PARTICIPANT_REPO_ID }}
+    participant_repo_name: ${{github.event.client_payload.repository}}
+    participant_repo_private: ${{env.PARTICIPANT_REPO_PRIVATE}}
+    log_url: ${{ env.LOG_URL }}
+    repo_token: ${{ secrets.REPO_TOKEN }}
+    upload_performances: false
 ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,19 @@ This composite action works with environment variables as input, two mandatory a
 
 ### Mandatory Input
 
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| `participant_repo_id` | The ID of the participant repository | true |  |
+| `participant_repo_name` | The name of the participant repository | true |  |
+| `participant_repo_private` | Whether the participant repository is private | true |  |
+| `log_url` | The URL of GitHub action logs | true |  |
+| `repo_token` | The GitHub token | true |  |
+| `upload_performances` | Whether to upload the performances to the cloud | false | `false` |
+
+<!--
 - INPUT_INDIVIDUAL_EVALUATION: information about the repository of the participant with the following format: `id:repository:private`, e.g., `348767863:omichel/my-competitor:true`.
 - INPUT_REPO_TOKEN: token used to fetch the participant repository, typically REPO_TOKEN. A more privileged token than GITHUB_TOKEN is needed to fetch controllers from private repositories.
+-->
 
 ### Optional Input
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,21 @@ This composite action works with environment variables as input, two mandatory a
 
 ### Mandatory Input
 
-| Name | Description | Required | Default |
-| --- | --- | --- | --- |
-| `participant_repo_id` | The ID of the participant repository | true |  |
-| `participant_repo_name` | The name of the participant repository | true |  |
-| `participant_repo_private` | Whether the participant repository is private | true |  |
-| `log_url` | The URL of GitHub action logs | true |  |
-| `repo_token` | The GitHub token | true |  |
-| `upload_performances` | Whether to upload the performances to the cloud | false | `false` |
+| Name | Description |
+| --- | --- |
+| `participant_repo_id` | The ID of the participant repository |
+| `participant_repo_name` | The name of the participant repository |
+| `participant_repo_private` | Whether the participant repository is private |
+| `log_url` | The URL of GitHub action logs |
+| `repo_token` | Token used to fetch the participant repository, typically REPO_TOKEN |
 
-<!--
-- INPUT_INDIVIDUAL_EVALUATION: information about the repository of the participant with the following format: `id:repository:private`, e.g., `348767863:omichel/my-competitor:true`.
-- INPUT_REPO_TOKEN: token used to fetch the participant repository, typically REPO_TOKEN. A more privileged token than GITHUB_TOKEN is needed to fetch controllers from private repositories.
--->
+A more privileged token than GITHUB_TOKEN is needed to fetch controllers from private repositories.
 
 ### Optional Input
 
-- INPUT_ALLOW_PUSH: allows the action to push the modified files after the evaluation using the INPUT_REPO_TOKEN.
+| Name | Description | Default |
+| --- | --- | --- |
+| `upload_performances` | Whether to upload the performances to the cloud | `false` |
 
 ## Python Code Pipeline
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that a more privileged token than `GITHUB_TOKEN` is required to fetch contr
 
 | Name | Description | Default |
 | --- | --- | --- |
-| `upload_performances` | Whether to upload the performances to the cloud | `false` |
+| `upload_performance` | Whether to upload the performance to webots.cloud | `false` |
 
 ## Python Code Pipeline
 
@@ -41,14 +41,14 @@ We then run Webots and the participant's controller inside Docker containers. We
 
 The animator records and saves the animation files and the competition performance in the temporary storage.
 
-If the competition is in a tournament format, the controller keeps on duelling the controller above it in the ranking until it loses in a bubble-sort logic.
+If the competition is in a ranking format, the controller keeps on dueling the controller above it in the ranking until it loses in a bubble-sort logic.
 
 The JSON animation file is renamed as `animation.json` and is moved to a directory `storage/{id}`.
 The `participants.json` file is also updated with the new recorded performance.
 
-### 3. Upload performances to webots.cloud (if UPLOAD_PERFORMANCES is set)
+### 3. Upload performance to webots.cloud (if UPLOAD_PERFORMANCE is set)
 
-If `UPLOAD_PERFORMANCES` is set, `animation.json` and the updated `participants.json` are uploaded to webots.cloud.
+If `UPLOAD_PERFORMANCE` is set, `animation.json` and the updated `participants.json` are uploaded to webots.cloud.
 
 ## Workflow
 
@@ -63,5 +63,5 @@ Here is a GitHub workflow snippet which uses the composite action:
     participant_repo_private: ${{env.PARTICIPANT_REPO_PRIVATE}}
     log_url: ${{ env.LOG_URL }}
     repo_token: ${{ secrets.REPO_TOKEN }}
-    upload_performances: false
+    upload_performance: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,31 @@
 name: 'Competition Record'
 description: 'Build and publish Webots animation and save competition score'
 inputs:
-  participant-repo-id:
+  participant_repo_id:
     description: 'The ID of the participant repository'
     required: true
-  participant-repo-name:
+
+  participant_repo_name:
     description: 'The name of the participant repository'
     required: true
-  participant-repo-private:
+
+  participant_repo_private:
     description: 'Whether the participant repository is private'
     required: true
-  log-url:
+
+  log_url:
     description: 'The URL of GitHub action logs'
     required: true
-  repo-token:
+
+  repo_token:
     description: 'The GitHub token'
     required: true
-  allow-push:
-    description: 'Whether to allow pushing to the participant repository'
+
+  upload_performances:
+    description: 'Whether to upload the performances to the cloud'
     required: false
     default: 'false'
+
 branding:
   icon: 'play'
   color: 'red'
@@ -30,6 +36,13 @@ runs:
     - name: Run the python meta script
       run: |
         env
-#        cp -r ${{ github.action_path }}/metascript .
-#        python3 -u -m metascript
+        cp -r ${{ github.action_path }}/metascript .
+        python3 -u -m metascript
       shell: bash
+      env:
+        PARTICIPANT_REPO_ID: ${{ inputs.participant_repo_id }}
+        PARTICIPANT_REPO_NAME: ${{ inputs.participant_repo_name }}
+        PARTICIPANT_REPO_PRIVATE: ${{ inputs.participant_repo_private }}
+        LOG_URL: ${{ inputs.log_url }}
+        REPO_TOKEN: ${{ inputs.repo_token }}
+        UPLOAD_PERFORMANCES: ${{ inputs.upload_performances }}

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,6 @@ runs:
   steps:
     - name: Run the python meta script
       run: |
-        env
         cp -r ${{ github.action_path }}/metascript .
         python3 -u -m metascript
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,8 @@ inputs:
     description: 'The GitHub token'
     required: true
 
-  upload_performances:
-    description: 'Whether to upload the performances to the cloud'
+  upload_performance:
+    description: 'Whether to upload the performance to the cloud'
     required: false
     default: 'false'
 
@@ -44,4 +44,4 @@ runs:
         PARTICIPANT_REPO_PRIVATE: ${{ inputs.participant_repo_private }}
         LOG_URL: ${{ inputs.log_url }}
         REPO_TOKEN: ${{ inputs.repo_token }}
-        UPLOAD_PERFORMANCES: ${{ inputs.upload_performances }}
+        UPLOAD_PERFORMANCE: ${{ inputs.upload_performance }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,25 @@
 name: 'Competition Record'
 description: 'Build and publish Webots animation and save competition score'
+inputs:
+  participant-repo-id:
+    description: 'The ID of the participant repository'
+    required: true
+  participant-repo-name:
+    description: 'The name of the participant repository'
+    required: true
+  participant-repo-private:
+    description: 'Whether the participant repository is private'
+    required: true
+  log-url:
+    description: 'The URL of GitHub action logs'
+    required: true
+  repo-token:
+    description: 'The GitHub token'
+    required: true
+  allow-push:
+    description: 'Whether to allow pushing to the participant repository'
+    required: false
+    default: 'false'
 branding:
   icon: 'play'
   color: 'red'
@@ -9,6 +29,7 @@ runs:
   steps:
     - name: Run the python meta script
       run: |
-        cp -r ${{ github.action_path }}/metascript .
-        python3 -u -m metascript
+        env
+#        cp -r ${{ github.action_path }}/metascript .
+#        python3 -u -m metascript
       shell: bash

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -185,10 +185,10 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'\033[32m{webots_line}\033[0m')
         if "' extern controller: waiting for connection on ipc://" in webots_line:
             if participant_docker is None and "INFO: 'participant' " in webots_line:
-                participant_docker = subprocess.Popen(['docker', 'run', '--rm', 'participant-controller'],
+                participant_docker = subprocess.Popen(['docker', 'run', '--gpus=all', '--rm', 'participant-controller'],
                                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
             elif opponent_docker is None and "INFO: 'opponent' " in webots_line:
-                opponent_docker = subprocess.Popen(['docker', 'run', '--rm', 'opponent-controller'],
+                opponent_docker = subprocess.Popen(['docker', 'run', '--gpus=all', '--rm', 'opponent-controller'],
                                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
         elif "' extern controller: connected" in webots_line:
             if "INFO: 'participant' " in webots_line:

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -127,7 +127,7 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'::group::Running evaluation in \033[32mWebots\033[0m of \033[31m{participant_name}\033[0m')
     command_line = ['docker', 'run', '--tty', '--rm']
     if gpu:
-        command_line += ['--gpus=all', '--env', 'DISPLAY',
+        command_line += ['--gpus', 'all', '--env', 'DISPLAY',
                          '--volume', '/tmp/.X11-unix:/tmp/.X11-unix:rw']
     else:
         command_line += ['--init']
@@ -185,10 +185,10 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'\033[32m{webots_line}\033[0m')
         if "' extern controller: waiting for connection on ipc://" in webots_line:
             if participant_docker is None and "INFO: 'participant' " in webots_line:
-                participant_docker = subprocess.Popen(['docker', 'run', '--gpus=all', '--rm', 'participant-controller'],
+                participant_docker = subprocess.Popen(['docker', 'run', '--gpus', 'all', '--rm', 'participant-controller'],
                                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
             elif opponent_docker is None and "INFO: 'opponent' " in webots_line:
-                opponent_docker = subprocess.Popen(['docker', 'run', '--gpus=all', '--rm', 'opponent-controller'],
+                opponent_docker = subprocess.Popen(['docker', 'run', '--gpus', 'all', '--rm', 'opponent-controller'],
                                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
         elif "' extern controller: connected" in webots_line:
             if "INFO: 'participant' " in webots_line:

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -23,7 +23,7 @@ TMP_ANIMATION_DIRECTORY = 'tmp'
 PERFORMANCE_KEYWORD = 'performance:'
 
 
-# return 1 if participant wins, 0 if participan loses and -1 if participant fails (due to an error)
+# return 1 if participant wins, 0 if participant loses and -1 if participant fails (due to an error)
 def record_animations(gpu, config, participant_controller_path, participant_name,
                       opponent_controller_path=None, opponent_name='', first_run=True):
     world_config = config['world']
@@ -214,7 +214,7 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         performance = -1
     if opponent_docker and not opponent_controller_connected:
         print('::warning ::Competition finished before the opponent controller connected to Webots: ' +
-              'the opponent controller failed conntected to Webots, therefore you won')
+              'the opponent controller failed to connect to Webots, therefore you won')
         performance = 1
 
     _close_containers()
@@ -249,7 +249,7 @@ def _get_realtime_stdout(process):
     return process.returncode
 
 
-def _close_containers():  # clearning containers possibly remaining after the last job
+def _close_containers():  # clearing containers possibly remaining after the last job
     webots_container_id = _get_container_id('recorder-webots')
     if webots_container_id != '':  # Closing Webots with SIGINT to trigger animation export
         subprocess.run(['docker', 'exec', webots_container_id, 'pkill', '-SIGINT', 'webots-bin'])
@@ -259,5 +259,3 @@ def _close_containers():  # clearning containers possibly remaining after the la
     opponent_controller_container_id = _get_container_id('opponent-controller')
     if opponent_controller_container_id != '':
         subprocess.run(['docker', 'kill', opponent_controller_container_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-    

--- a/metascript/animation.py
+++ b/metascript/animation.py
@@ -121,8 +121,8 @@ def record_animations(gpu, config, participant_controller_path, participant_name
 
     # Run Webots container with Popen to read the stdout
     if opponent_controller_path:
-        print(f'::group::Running game in \033[32mWebots\033[0m: \033[31m{participant_name}\033[0m ' +
-              f'versus \033[34m{opponent_name}\033[0m')
+        print(f'::group::Running game in \033[32mWebots\033[0m: \033[31m{participant_name}\033[0m '
+              + f'versus \033[34m{opponent_name}\033[0m')
     else:
         print(f'::group::Running evaluation in \033[32mWebots\033[0m of \033[31m{participant_name}\033[0m')
     command_line = ['docker', 'run', '--tty', '--rm']
@@ -133,9 +133,9 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         command_line += ['--init']
 
     command_line += [
-        '--mount', 'type=bind,' +
-                   f'source={os.getcwd()}/{TMP_ANIMATION_DIRECTORY},' +
-                   f'target=/usr/local/webots-project/{TMP_ANIMATION_DIRECTORY}',
+        '--mount', 'type=bind,'
+                   + f'source={os.getcwd()}/{TMP_ANIMATION_DIRECTORY},'
+                   + f'target=/usr/local/webots-project/{TMP_ANIMATION_DIRECTORY}',
         '--publish', '3005:1234',
         '--env', 'CI=true',
         '--env', f'PARTICIPANT_NAME={participant_name}',
@@ -205,16 +205,16 @@ def record_animations(gpu, config, participant_controller_path, participant_name
         print(f'::error ::Webots container exited with code {webots_docker.returncode}')
         performance = -1
     if not participant_docker:
-        print('::error ::Competition finished before launching the participant controller: ' +
-              'check that the controller in the world file is named "participant"')
+        print('::error ::Competition finished before launching the participant controller: '
+              + 'check that the controller in the world file is named "participant"')
         performance = -1
     if not participant_controller_connected:
-        print('::error ::Competition finished before the participant controller connected to Webots: ' +
-              'your controller crashed. Please debug your controller locally before submitting it')
+        print('::error ::Competition finished before the participant controller connected to Webots: '
+              + 'your controller crashed. Please debug your controller locally before submitting it')
         performance = -1
     if opponent_docker and not opponent_controller_connected:
-        print('::warning ::Competition finished before the opponent controller connected to Webots: ' +
-              'the opponent controller failed to connect to Webots, therefore you won')
+        print('::warning ::Competition finished before the opponent controller connected to Webots: '
+              + 'the opponent controller failed to connect to Webots, therefore you won')
         performance = 1
 
     _close_containers()
@@ -255,7 +255,9 @@ def _close_containers():  # clearing containers possibly remaining after the las
         subprocess.run(['docker', 'exec', webots_container_id, 'pkill', '-SIGINT', 'webots-bin'])
     participant_controller_container_id = _get_container_id('participant-controller')
     if participant_controller_container_id != '':
-        subprocess.run(['docker', 'kill', participant_controller_container_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ['docker', 'kill', participant_controller_container_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     opponent_controller_container_id = _get_container_id('opponent-controller')
     if opponent_controller_container_id != '':
-        subprocess.run(['docker', 'kill', opponent_controller_container_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ['docker', 'kill', opponent_controller_container_id], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -54,8 +54,8 @@ class Participant:
                 else:
                     country = self.data['country']
                     if country != 'demo' and len(country) != 2:
-                        print(f'{message}Bad country code in {url} (you should set a two-letter country code, see ' +
-                              'https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 for details)')
+                        print(f'{message}Bad country code in {url} (you should set a two-letter country code, see '
+                              + 'https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 for details)')
                         if not opponent:
                             sys.exit(1)
         else:
@@ -81,13 +81,13 @@ def competition(config):
 
     response = requests.get(f'https://webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
     open("participants.json", "wb").write(response.content)
-    
+
     # Parse input participant
     participant = _get_participant()
     if participant.data is None:
-        print('::error ::Cannot parse ' +
-              f'https://github.com/{participant.repository}/blob/main/controllers/participant/participant.json, ' +
-              'please provide or fix this file.')
+        print('::error ::Cannot parse '
+              + f'https://github.com/{participant.repository}/blob/main/controllers/participant/participant.json, '
+              + 'please provide or fix this file.')
         sys.exit(1)
     performance = None
     animator_controller_destination_path = _copy_animator_files()
@@ -184,9 +184,7 @@ def _get_opponent(participant):
 
 
 def _get_participant():
-    input_participant = os.environ['INPUT_INDIVIDUAL_EVALUATION']
-    split = input_participant.split(':')
-    print(f'Cloning \033[31mparticipant\033[0m repository: {split[1]}')
+    print(f'Cloning \033[31mparticipant\033[0m repository: {os.environ["PARTICIPANT_REPO_NAME"]}')
     participant = Participant(
         os.environ['PARTICIPANT_REPO_ID'],
         os.environ['PARTICIPANT_REPO_NAME'],
@@ -272,8 +270,8 @@ def _update_ranking(performance, participant, opponent):
             _update_participant(found_participant, opponent, rank + 1)
         else:  # insert participant at last but one position, move opponent to last position
             if found_opponent['performance'] != count - 1:
-                print('::error ::Opponent should be ranked last in participants.json ' +
-                      f'({found_opponent["performance"]} != {count - 1})')
+                print('::error ::Opponent should be ranked last in participants.json '
+                      + f'({found_opponent["performance"]} != {count - 1})')
                 sys.exit(1)
             _update_participant(found_opponent, opponent, count)
             p = {}

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -24,7 +24,7 @@ import sys
 from .animation import record_animations, TMP_ANIMATION_DIRECTORY
 from .utils import git, webots_cloud
 
-UPLOAD_PERFORMANCES = os.getenv('UPLOAD_PERFORMANCES', 'false') == 'true'
+UPLOAD_PERFORMANCES = os.environ['UPLOAD_PERFORMANCES'] == 'True'
 
 
 class Participant:

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -79,7 +79,8 @@ def competition(config):
 
     git.init()
 
-    response = requests.get(f'https://webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
+    response = requests.get(
+        f'https://benchmark.webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
     open("participants.json", "wb").write(response.content)
 
     # Parse input participant

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -17,6 +17,7 @@
 from datetime import datetime, timezone
 import json
 import os
+import re
 import requests
 import shutil
 import subprocess
@@ -24,7 +25,8 @@ import sys
 from .animation import record_animations, TMP_ANIMATION_DIRECTORY
 from .utils import git, webots_cloud
 
-UPLOAD_PERFORMANCES = os.environ['UPLOAD_PERFORMANCES'] == 'true'
+# YAML booleans are converted to strings by GitHub composite Actions, so we need to convert them back to booleans
+UPLOAD_PERFORMANCES = re.search("y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON", os.environ['UPLOAD_PERFORMANCES'])
 print("os.environ['UPLOAD_PERFORMANCES']", os.environ['UPLOAD_PERFORMANCES'])
 print("UPLOAD_PERFORMANCES", UPLOAD_PERFORMANCES)
 

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -84,7 +84,7 @@ def competition(config):
     git.init()
 
     response = requests.get(
-        f'https://benchmark.webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
+        f'https://webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
     open("participants.json", "wb").write(response.content)
 
     # Parse input participant

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -25,6 +25,8 @@ from .animation import record_animations, TMP_ANIMATION_DIRECTORY
 from .utils import git, webots_cloud
 
 UPLOAD_PERFORMANCES = os.environ['UPLOAD_PERFORMANCES'] == 'True'
+print("os.environ['UPLOAD_PERFORMANCES']", os.environ['UPLOAD_PERFORMANCES'])
+print("UPLOAD_PERFORMANCES", UPLOAD_PERFORMANCES)
 
 
 class Participant:

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -82,6 +82,7 @@ def competition(config):
     response = requests.get(
         f'https://benchmark.webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
     open("participants.json", "wb").write(response.content)
+    print(response.content)
 
     # Parse input participant
     participant = _get_participant()

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -24,7 +24,7 @@ import sys
 from .animation import record_animations, TMP_ANIMATION_DIRECTORY
 from .utils import git, webots_cloud
 
-UPLOAD_PERFORMANCES = os.environ['UPLOAD_PERFORMANCES'] == 'True'
+UPLOAD_PERFORMANCES = os.environ['UPLOAD_PERFORMANCES'] == 'true'
 print("os.environ['UPLOAD_PERFORMANCES']", os.environ['UPLOAD_PERFORMANCES'])
 print("UPLOAD_PERFORMANCES", UPLOAD_PERFORMANCES)
 

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -26,9 +26,7 @@ from .animation import record_animations, TMP_ANIMATION_DIRECTORY
 from .utils import git, webots_cloud
 
 # YAML booleans are converted to strings by GitHub composite Actions, so we need to convert them back to booleans
-UPLOAD_PERFORMANCES = re.search("y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON", os.environ['UPLOAD_PERFORMANCES'])
-print("os.environ['UPLOAD_PERFORMANCES']", os.environ['UPLOAD_PERFORMANCES'])
-print("UPLOAD_PERFORMANCES", UPLOAD_PERFORMANCES)
+UPLOAD_PERFORMANCES = re.search(r"^(?:y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON)$", os.environ['UPLOAD_PERFORMANCES'])
 
 
 class Participant:
@@ -86,7 +84,6 @@ def competition(config):
     response = requests.get(
         f'https://benchmark.webots.cloud/storage/competition/{os.environ["GITHUB_REPOSITORY"]}/participants.json')
     open("participants.json", "wb").write(response.content)
-    print(response.content)
 
     # Parse input participant
     participant = _get_participant()

--- a/metascript/competition.py
+++ b/metascript/competition.py
@@ -26,7 +26,7 @@ from .animation import record_animations, TMP_ANIMATION_DIRECTORY
 from .utils import git, webots_cloud
 
 # YAML booleans are converted to strings by GitHub composite Actions, so we need to convert them back to booleans
-UPLOAD_PERFORMANCES = re.search(r"^(?:y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON)$", os.environ['UPLOAD_PERFORMANCES'])
+UPLOAD_PERFORMANCE = re.search(r"^(?:y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON)$", os.environ['UPLOAD_PERFORMANCE'])
 
 
 class Participant:
@@ -137,7 +137,7 @@ def competition(config):
     # cleanup docker containers, images and networks not used in the last 30 days
     subprocess.check_output(['docker', 'system', 'prune', '--force', '--filter', 'until=720h'])
 
-    if UPLOAD_PERFORMANCES:
+    if UPLOAD_PERFORMANCE:
         webots_cloud.upload_file(os.environ['GITHUB_REPOSITORY'], os.environ['REPO_TOKEN'], 'participants.json',
                                  'participants')
         if os.path.isdir('storage'):

--- a/metascript/utils/git.py
+++ b/metascript/utils/git.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import requests
 import subprocess
 
 
@@ -24,26 +22,6 @@ def init():
     if result.returncode != 0:
         subprocess.check_output(['git', 'config', '--global', 'user.name', 'webots.cloud'])
         subprocess.check_output(['git', 'config', '--global', 'user.email', '97463320+webots-cloud@users.noreply.github.com'])
-
-
-def push(message='Updated competition recordings'):
-    github_repository = 'https://{}:{}@github.com/{}'.format(
-        os.environ['GITHUB_ACTOR'],
-        os.environ['INPUT_REPO_TOKEN'],
-        os.environ['GITHUB_REPOSITORY']
-    )
-    print(f'::group::Push new animations and ranking to https://github.com/{os.environ["GITHUB_REPOSITORY"]}')
-    try:
-        if os.path.exists('participants.json'):
-            subprocess.check_output(['git', 'add', '-A', 'participants.json'])
-        if os.path.exists('storage'):
-            subprocess.check_output(['git', 'add', '-A', 'storage'])
-        print(subprocess.check_output(['git', 'commit', '-m', message], stderr=subprocess.STDOUT).decode('utf-8'))
-        print(subprocess.check_output(['git', 'push', '-f', github_repository]).decode('utf-8'))
-    except subprocess.CalledProcessError:
-        print('::notice ::Nothing to commit and push')
-    print('::endgroup::')
-
 
 def clone(repo, path):
     try:

--- a/metascript/utils/git.py
+++ b/metascript/utils/git.py
@@ -23,6 +23,7 @@ def init():
         subprocess.check_output(['git', 'config', '--global', 'user.name', 'webots.cloud'])
         subprocess.check_output(['git', 'config', '--global', 'user.email', '97463320+webots-cloud@users.noreply.github.com'])
 
+
 def clone(repo, path):
     try:
         subprocess.check_output(['git', 'clone', '--depth=1', '-q', repo, path])

--- a/metascript/utils/webots_cloud.py
+++ b/metascript/utils/webots_cloud.py
@@ -20,5 +20,5 @@ import requests
 def upload_file(repository, token, file, name):
     data = {'path': file, 'repository': repository, 'token': token}
     with open(file, 'rb') as f:
-        response = requests.post('https://benchmark.webots.cloud/ajax/project/upload.php', files={name: f}, data=data)
+        response = requests.post('https://webots.cloud/ajax/project/upload.php', files={name: f}, data=data)
         print(response.text)

--- a/metascript/utils/webots_cloud.py
+++ b/metascript/utils/webots_cloud.py
@@ -20,5 +20,5 @@ import requests
 def upload_file(repository, token, file, name):
     data = {'path': file, 'repository': repository, 'token': token}
     with open(file, 'rb') as f:
-        response = requests.post('https://webots.cloud/ajax/project/upload.php', files={name: f}, data=data)
+        response = requests.post('https://benchmark.webots.cloud/ajax/project/upload.php', files={name: f}, data=data)
         print(response.text)


### PR DESCRIPTION
This PR makes the action use GitHub Actions's inputs as mentionned in #22

It also updates the README to the latest changes and fixes some linting errors. The "push" part of the git script was also removed as it is not needed anymore.

If this PR is merged, the competitions will need to change their call to this GitHub action [similarly to this](https://github.com/Jean-Eudes-le-retour/robot-programming-perso/blob/main/.github/workflows/run.yml#L54-L63)

I will need to convert the benchmark.webots.cloud reference to webots.cloud before merging

It can be tested on https://benchmark.webots.cloud/run?version=R2023a&url=https%3A%2F%2Fgithub.com%2FJean-Eudes-le-retour%2Frobot-programming-perso%2Fblob%2Fcompetition%2Fworlds%2Frobot_programming.wbt&type=competition

Closes #22